### PR TITLE
Standardize Field Formatting and Improve Clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Submit your Sequencer information, which will be displayed on the Metis Decentra
 5. Submit a pull request
 
 ## Requirements
-* `name` The name of your Sequencer, may be max 24 characters
-* `avatar` must place in this repository's /assets path
-  * Must begin with your name  and a `.png` or `.svg` file extension
+* `name`: The name of your Sequencer, must not exceed 24 characters
+* `avatar`: must be placed in this repository's /assets path
+  * Must begin with your name and a `.png` or `.svg` file extension
   * Must fulfill the [PNG/SVG image requirements](#PNG/SVG-image-requirements)
-* `desc` A brief description of yourself or your organization, may be max 200 characters
-* `address` Your whitelist address for sequencer lock-up. Must be 42-character long hexadecimal strings that start with '0x'.
-* `seq_addr` The Sequencer address provided by the server after you run the Sequencer. Must be 42-character long hexadecimal strings that start with '0x'.
-* `pubkey` The public key provided by the server after you run the Sequencer. Must be 64 bytes (128 hexadecimal characters) long. Please delete the '04' character in its original format.
-* `url` A link to your website or x.com profile. Must be prefixed with https://
-* `lst_name` The name of the LST associated with the Sequencer. Optional, with a maximum of 24 characters.
-* `lst_url` A link to your website or x.com profile. Must be prefixed with https://
+* `desc`: A brief description of yourself or your organization, must not exceed 200 characters
+* `address`: Your whitelist address for sequencer lock-up. Must be 42-character long hexadecimal strings that start with '0x'.
+* `seq_addr`: The Sequencer address provided by the server after you run the Sequencer. Must be 42-character long hexadecimal strings that start with '0x'.
+* `pubkey`: The public key provided by the server after you run the Sequencer. Must be 64 bytes (128 hexadecimal characters) long. Please delete the '04' character in its original format.
+* `url`: A link to your website or x.com profile. Must be prefixed with https://
+* `lst_name`: The name of the LST associated with the Sequencer. Optional, with a maximum of 24 characters.
+* `lst_url`: A link to your website or x.com profile. Must be prefixed with https://
 
 ### PNG/SVG Image Requirements
 * Use the same width and height for the aspect ratio of 1 


### PR DESCRIPTION
### 1. **Added Missing Colons to Field Names**  
   - Added missing colons after field names to match the example format. The following fields were updated: `name`, `avatar`, `desc`, `address`, `seq_addr`, `pubkey`, `url`, `lst_name`, `lst_url`.  
   - Example shows `"name":` format, but the main documentation was missing these colons.

![image](https://github.com/user-attachments/assets/046d5570-ffae-4356-a40c-b8de2b5ae44d)

### 2. **Improved Clarity of Sequencer Name Requirement**  
   - The phrase **"The name of your Sequencer, may be max 24 characters"** was changed to **"The name of your Sequencer, must not exceed 24 characters"** for better clarity and readability.

### Before:  
`"name" The name of your Sequencer, may be max 24 characters`

### After:  
`"name": The name of your Sequencer, must not exceed 24 characters`
